### PR TITLE
Resolve the require path relative to the parent module's directory.

### DIFF
--- a/src/requiredir.js
+++ b/src/requiredir.js
@@ -13,14 +13,18 @@ module.exports = (function(){
 			throw new Error("The path must be provided when instantiating the object.");
 		}
 
+		// Resolve the full path so that if an error occurs
+		// we can show the user the absolute path, for clarity.
+		path = _path.resolve(path);
+
 		try {
 			stats = _fs.statSync(path);
 		} catch (e) {
-			throw new Error("The directory path does not exist.");
+			throw new Error("The directory path does not exist. [" + path + "]");
 		}
 
 		if (!stats.isDirectory()){
-			throw new Error("The path provided is not a directory.");
+			throw new Error("The path provided is not a directory. [" + path + "]");
 		}
 	};
 

--- a/src/requiredir.js
+++ b/src/requiredir.js
@@ -10,18 +10,17 @@ module.exports = (function(){
 
 		if (typeof path === "undefined"
 			|| (typeof path === "string" && path.trim().length === 0)) {
-			throw new TypeError("The path must be provided when instantiating the object.");
+			throw new Error("The path must be provided when instantiating the object.");
 		}
 
 		try {
 			stats = _fs.statSync(path);
-
 		} catch (e) {
-			throw new TypeError("The directory path does not exist.");
+			throw new Error("The directory path does not exist.");
 		}
 
 		if (!stats.isDirectory()){
-			throw new TypeError("The path provided is not a directory.");
+			throw new Error("The path provided is not a directory.");
 		}
 	};
 

--- a/src/requiredir.js
+++ b/src/requiredir.js
@@ -30,15 +30,15 @@ module.exports = (function(){
 
 	var _importFiles = function(path, files){
 		var moduleList = []
-			, relativePath = _path.resolve(process.cwd() + "/" + path)
+			, relativePath = _path.resolve(_path.join(process.cwd(), path))
 			, trimmedName
 			, module
 			, obj = {};
 
 		files.forEach(function (element, index, array){
-			if (_fs.lstatSync(path + "/" + element).isFile() && element.substring(0,1) !== "."){
+			if (_fs.lstatSync(_path.join(path, element)).isFile() && element.substring(0,1) !== "."){
 				trimmedName =  element.substring(0, (element.length - 3));
-				module = require(relativePath + "/" + trimmedName);			
+				module = require(_path.join(relativePath, trimmedName));			
 				moduleList.push(module);
 				obj[trimmedName] = module;
 			}

--- a/src/requiredir.js
+++ b/src/requiredir.js
@@ -36,8 +36,9 @@ module.exports = (function(){
 			, obj = {};
 
 		files.forEach(function (element, index, array){
+			// Require each file, skipping dotfiles.
 			if (_fs.lstatSync(_path.join(path, element)).isFile() && element.substring(0,1) !== "."){
-				trimmedName =  element.substring(0, (element.length - 3));
+				trimmedName = _path.basename(element, _path.extname(element));
 				module = require(_path.join(relativePath, trimmedName));			
 				moduleList.push(module);
 				obj[trimmedName] = module;

--- a/tests/requiredir-tests.js
+++ b/tests/requiredir-tests.js
@@ -2,7 +2,8 @@
 var _mocha = require("mocha")
 	, _should = require("should")
 	, _helpers = require("./test-helpers")
-	, requiredir = require("../src/requiredir");
+	, requiredir = require("../src/requiredir")
+	, _path = require("path");
 	
 describe("requiredir.js", function(){
 	describe("Instantiation", function(){
@@ -20,11 +21,13 @@ describe("requiredir.js", function(){
 		});
 		
 		it("should throw an exception if the path does not exist.", function(){
-			(function(){requiredir("./doesnotexist");}).should.throw("The directory path does not exist.");
+			var pathToTest = "./doesnotexist";
+			(function(){requiredir(pathToTest);}).should.throw("The directory path does not exist. [" + _path.resolve(pathToTest) + "]");
 		});
 		
 		it("should throw an exception if the path is not a directory.", function(){
-			(function(){requiredir("./LICENSE");}).should.throw("The path provided is not a directory.");
+			var pathToTest = "./LICENSE";
+			(function(){requiredir(pathToTest);}).should.throw("The path provided is not a directory. [" + _path.resolve(pathToTest) + "]");
 		});
 	});
 	

--- a/tests/requiredir-tests.js
+++ b/tests/requiredir-tests.js
@@ -22,12 +22,12 @@ describe("requiredir.js", function(){
 		
 		it("should throw an exception if the path does not exist.", function(){
 			var pathToTest = "./doesnotexist";
-			(function(){requiredir(pathToTest);}).should.throw("The directory path does not exist. [" + _path.resolve(pathToTest) + "]");
+			(function(){requiredir(pathToTest);}).should.throw("The directory path does not exist. [" + _path.resolve(__dirname, pathToTest) + "]");
 		});
 		
 		it("should throw an exception if the path is not a directory.", function(){
-			var pathToTest = "./LICENSE";
-			(function(){requiredir(pathToTest);}).should.throw("The path provided is not a directory. [" + _path.resolve(pathToTest) + "]");
+			var pathToTest = "../LICENSE";
+			(function(){requiredir(pathToTest);}).should.throw("The path provided is not a directory. [" + _path.resolve(__dirname, pathToTest) + "]");
 		});
 	});
 	

--- a/tests/test-helpers.js
+++ b/tests/test-helpers.js
@@ -1,8 +1,9 @@
 "use strict";
 
 var _fs = require("fs")
-	, _os = require('os')
-	, _rimraf = require("rimraf");
+	, _os = require("os")
+	, _rimraf = require("rimraf")
+	, _path = require("path");
 
 var eol = _os.platform
   ? ('win32' == _os.platform() ? '\r\n' : '\n')
@@ -17,19 +18,22 @@ var index = [
 
 var createTestFiles = function(path, count){
 	for (var i = 0; i <  count; i++){
-		_fs.writeFileSync(path + '/mod' + i + '.js', index);
+		_fs.writeFileSync(_path.join(path, '/mod' + i + '.js'), index);
 	}
 };
 
 exports.createHiddenTestFiles = function(path){
-	_fs.writeFileSync(path + '/.hiddenFile.js', index);
+	path = _path.resolve(_path.dirname(module.parent.filename), path);
+	_fs.writeFileSync(_path.join(path, '/.hiddenFile.js'), index);
 };
 
 exports.setup = function(path, count){
+	path = _path.resolve(_path.dirname(module.parent.filename), path);
 	_fs.mkdirSync(path);
 	createTestFiles(path, count);
 };
 
 exports.teardown = function(path){
+	path = _path.resolve(_path.dirname(module.parent.filename), path);
 	_rimraf.sync(path);
 };


### PR DESCRIPTION
Currently requiredir resolves paths relative to `process.cwd()`. This is not always the expected behavior.

I would expect to be able to pass a path that is relative to the current script's directory, which is consistent with how `require()` works.

For example, given the following structure:

```
/app
  /routes
    /api
      /people.js
    /index.js

  /server.js
```

Calling `requiredir('./api')` from `./routes/index.js` would try to import all files from `/app/api`.

This pull request fixes it so that it would correctly import from `/app/routes/api`.
